### PR TITLE
Added Search Menu Script smenu_1

### DIFF
--- a/polybar-2/scripts/smenu_1
+++ b/polybar-2/scripts/smenu_1
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+## Created By Haider Ali Punjabi (https://github.com/haideralipunjabi)
+
+MENU="$(rofi -dmenu -i -p 'Search' -location 1 -yoffset 60 -xoffset 100 -width 15 -hide-scrollbar -line-padding 4 -padding 20 -lines 0 -font "Fantasque Sans Mono 10" <<< "")"
+if ["$MENU" != ""]
+    then
+        xdg-open https://www.google.com/search?q=$MENU


### PR DESCRIPTION
The script can be best used in the `[module/google]` as `click-right`.
I haven't added that in the `config`, but you may if you like it.

What it does:
Opens a menu to input search text in, which opens in Google.