### PR TITLE
Fixed incorrect Font naming on Polybar-5

### DIFF
--- a/polybar-5/config.ini
+++ b/polybar-5/config.ini
@@ -140,15 +140,15 @@ module-margin-right = 0
 ;;font-2 = "xos4 Terminus:size=12;1"
 
 ; Text Fonts
-font-0 = Iosevka Nerd Font:style=Medium:size=10;3
+font-0 = Iosevka:style=Medium:size=10;3
 ; Icons Fonts
 font-1 = icomoon\-feather:style=Medium:size=10;3
 ; Powerline Glyphs
-font-2 = Iosevka Nerd Font:style=Medium:size=16;3
+font-2 = Iosevka:style=Medium:size=16;3
 ; Larger font size for bar fill icons
-font-3 = Iosevka Nerd Font:style=Medium:size=12;3
+font-3 = Iosevka:style=Medium:size=12;3
 ; Smaller font size for shorter spaces
-font-4 = Iosevka Nerd Font:style=Medium:size=7;3
+font-4 = Iosevka:style=Medium:size=7;3
 
 
 ; Modules are added to one of the available blocks


### PR DESCRIPTION
The font file for polybar 5 that is included should be 'Iosevka' instead of 'Iovseka Nerd Font' as seen in lines 143 - 151