### PR TITLE
Added padding to cpu module

### DIFF
--- a/polybar-5/modules.ini
+++ b/polybar-5/modules.ini
@@ -391,9 +391,9 @@ format-padding = ${layout.module-padding}
 ;   %percentage-sum% - Cumulative load on all cores
 ;   %percentage-cores% - load percentage for each core
 ;   %percentage-core[1-9]% - load percentage for specific core
-;   FIXED: Added :3 to %percentage%% to stop annoying movement of cpu module in live use
+;   FIXED: Added :2 to %percentage%% to stop annoying movement of cpu module in live use
 ;       -See "https://github.com/jaagr/polybar/wiki/Formatting#tokens" for more info.
-label = " %percentage:3%%"
+label = " %percentage:2%%"
 
 ; Spacing between individual per-core ramps
 ;;ramp-coreload-spacing = 1

--- a/polybar-5/modules.ini
+++ b/polybar-5/modules.ini
@@ -391,7 +391,9 @@ format-padding = ${layout.module-padding}
 ;   %percentage-sum% - Cumulative load on all cores
 ;   %percentage-cores% - load percentage for each core
 ;   %percentage-core[1-9]% - load percentage for specific core
-label = " %percentage%%"
+;   FIXED: Added :3 to %percentage%% to stop annoying movement of cpu module in live use
+;       -See "https://github.com/jaagr/polybar/wiki/Formatting#tokens" for more info.
+label = " %percentage:3%%"
 
 ; Spacing between individual per-core ramps
 ;;ramp-coreload-spacing = 1


### PR DESCRIPTION
Since the cpu module bounces between single and double digit numbers it creates an annoying movement.

Adding the padding with the :2 adds room for double digits.

More info @ https://github.com/polybar/polybar/wiki/Formatting#tokens

I suppose we could add :3 in case someone makes it to 100% cpu usage but at that point there's some other problems going on.