### PR TITLE
Simplify fonts installation code

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -10,12 +10,8 @@ PDIR="$HOME/.config/polybar"
 # Install Fonts
 install_fonts() {
 	echo -e "\n[*] Installing fonts..."
-	if [[ -d "$FDIR" ]]; then
-		cp -rf $DIR/fonts/* "$FDIR"
-	else
-		mkdir -p "$FDIR"
-		cp -rf $DIR/fonts/* "$FDIR"
-	fi
+	[[ ! -d "$FDIR" ]] && mkdir -p "$FDIR"
+	cp -rf $DIR/fonts/* "$FDIR"
 }
 
 # Install Themes


### PR DESCRIPTION
Removes duplicated `cp` instructions and replaces it with single `mkdir` and `cp`