### PR TITLE
Patch powermenu weird display if host rofi config exist

### DIFF
--- a/bitmap/blocks/scripts/powermenu.sh
+++ b/bitmap/blocks/scripts/powermenu.sh
@@ -8,7 +8,7 @@
 dir="~/.config/polybar/blocks/scripts/rofi"
 uptime=$(uptime -p | sed -e 's/up //g')
 
-rofi_command="rofi -theme $dir/powermenu.rasi"
+rofi_command="rofi -no-config -theme $dir/powermenu.rasi"
 
 # Options
 shutdown=" Shutdown"

--- a/bitmap/blocks/scripts/powermenu.sh
+++ b/bitmap/blocks/scripts/powermenu.sh
@@ -20,6 +20,7 @@ logout=" Logout"
 # Confirmation
 confirm_exit() {
 	rofi -dmenu\
+        -no-config\
 		-i\
 		-no-fixed-num-lines\
 		-p "Are You Sure? : "\
@@ -28,7 +29,7 @@ confirm_exit() {
 
 # Message
 msg() {
-	rofi -theme "$dir/message.rasi" -e "Available Options  -  yes / y / no / n"
+	rofi -no-config -theme "$dir/message.rasi" -e "Available Options  -  yes / y / no / n"
 }
 
 # Variable passed to rofi

--- a/bitmap/colorblocks/scripts/powermenu.sh
+++ b/bitmap/colorblocks/scripts/powermenu.sh
@@ -20,7 +20,8 @@ logout=" Logout"
 # Confirmation
 confirm_exit() {
 	rofi -dmenu\
-		-i\
+		-no-config\
+        -i\
 		-no-fixed-num-lines\
 		-p "Are You Sure? : "\
 		-theme $dir/confirm.rasi
@@ -28,7 +29,7 @@ confirm_exit() {
 
 # Message
 msg() {
-	rofi -theme "$dir/message.rasi" -e "Available Options  -  yes / y / no / n"
+	rofi -no-config -theme "$dir/message.rasi" -e "Available Options  -  yes / y / no / n"
 }
 
 # Variable passed to rofi

--- a/bitmap/colorblocks/scripts/powermenu.sh
+++ b/bitmap/colorblocks/scripts/powermenu.sh
@@ -8,7 +8,7 @@
 dir="~/.config/polybar/colorblocks/scripts/rofi"
 uptime=$(uptime -p | sed -e 's/up //g')
 
-rofi_command="rofi -theme $dir/powermenu.rasi"
+rofi_command="rofi -no-config -theme $dir/powermenu.rasi"
 
 # Options
 shutdown=" Shutdown"

--- a/bitmap/cuts/scripts/powermenu.sh
+++ b/bitmap/cuts/scripts/powermenu.sh
@@ -8,7 +8,7 @@
 dir="~/.config/polybar/cuts/scripts/rofi"
 uptime=$(uptime -p | sed -e 's/up //g')
 
-rofi_command="rofi -theme $dir/powermenu.rasi"
+rofi_command="rofi -no-config -theme $dir/powermenu.rasi"
 
 # Options
 shutdown=" Shutdown"

--- a/bitmap/cuts/scripts/powermenu.sh
+++ b/bitmap/cuts/scripts/powermenu.sh
@@ -20,7 +20,8 @@ logout=" Logout"
 # Confirmation
 confirm_exit() {
 	rofi -dmenu\
-		-i\
+		-no-config\
+        -i\
 		-no-fixed-num-lines\
 		-p "Are You Sure? : "\
 		-theme $dir/confirm.rasi
@@ -28,7 +29,7 @@ confirm_exit() {
 
 # Message
 msg() {
-	rofi -theme "$dir/message.rasi" -e "Available Options  -  yes / y / no / n"
+	rofi -no-config -theme "$dir/message.rasi" -e "Available Options  -  yes / y / no / n"
 }
 
 # Variable passed to rofi

--- a/bitmap/docky/scripts/powermenu.sh
+++ b/bitmap/docky/scripts/powermenu.sh
@@ -20,7 +20,8 @@ logout=" Logout"
 # Confirmation
 confirm_exit() {
 	rofi -dmenu\
-		-i\
+		-no-config\
+        -i\
 		-no-fixed-num-lines\
 		-p "Are You Sure? : "\
 		-theme $dir/confirm.rasi
@@ -28,7 +29,7 @@ confirm_exit() {
 
 # Message
 msg() {
-	rofi -theme "$dir/message.rasi" -e "Available Options  -  yes / y / no / n"
+	rofi -no-config -theme "$dir/message.rasi" -e "Available Options  -  yes / y / no / n"
 }
 
 # Variable passed to rofi

--- a/bitmap/docky/scripts/powermenu.sh
+++ b/bitmap/docky/scripts/powermenu.sh
@@ -8,7 +8,7 @@
 dir="~/.config/polybar/docky/scripts/rofi"
 uptime=$(uptime -p | sed -e 's/up //g')
 
-rofi_command="rofi -theme $dir/powermenu.rasi"
+rofi_command="rofi -no-config -theme $dir/powermenu.rasi"
 
 # Options
 shutdown=" Shutdown"

--- a/bitmap/forest/scripts/powermenu.sh
+++ b/bitmap/forest/scripts/powermenu.sh
@@ -20,7 +20,8 @@ logout=" Logout"
 # Confirmation
 confirm_exit() {
 	rofi -dmenu\
-		-i\
+		-no-config\
+        -i\
 		-no-fixed-num-lines\
 		-p "Are You Sure? : "\
 		-theme $dir/confirm.rasi
@@ -28,7 +29,7 @@ confirm_exit() {
 
 # Message
 msg() {
-	rofi -theme "$dir/message.rasi" -e "Available Options  -  yes / y / no / n"
+	rofi -no-config -theme "$dir/message.rasi" -e "Available Options  -  yes / y / no / n"
 }
 
 # Variable passed to rofi

--- a/bitmap/forest/scripts/powermenu.sh
+++ b/bitmap/forest/scripts/powermenu.sh
@@ -8,7 +8,7 @@
 dir="~/.config/polybar/forest/scripts/rofi"
 uptime=$(uptime -p | sed -e 's/up //g')
 
-rofi_command="rofi -theme $dir/powermenu.rasi"
+rofi_command="rofi -no-config -theme $dir/powermenu.rasi"
 
 # Options
 shutdown=" Shutdown"

--- a/bitmap/grayblocks/scripts/powermenu.sh
+++ b/bitmap/grayblocks/scripts/powermenu.sh
@@ -20,7 +20,8 @@ logout=" Logout"
 # Confirmation
 confirm_exit() {
 	rofi -dmenu\
-		-i\
+		-no-config\
+        -i\
 		-no-fixed-num-lines\
 		-p "Are You Sure? : "\
 		-theme $dir/confirm.rasi
@@ -28,7 +29,7 @@ confirm_exit() {
 
 # Message
 msg() {
-	rofi -theme "$dir/message.rasi" -e "Available Options  -  yes / y / no / n"
+	rofi -no-config -theme "$dir/message.rasi" -e "Available Options  -  yes / y / no / n"
 }
 
 # Variable passed to rofi

--- a/bitmap/grayblocks/scripts/powermenu.sh
+++ b/bitmap/grayblocks/scripts/powermenu.sh
@@ -8,7 +8,7 @@
 dir="~/.config/polybar/grayblocks/scripts/rofi"
 uptime=$(uptime -p | sed -e 's/up //g')
 
-rofi_command="rofi -theme $dir/powermenu.rasi"
+rofi_command="rofi -no-config -theme $dir/powermenu.rasi"
 
 # Options
 shutdown=" Shutdown"

--- a/bitmap/hack/scripts/powermenu.sh
+++ b/bitmap/hack/scripts/powermenu.sh
@@ -20,7 +20,8 @@ logout=" Logout"
 # Confirmation
 confirm_exit() {
 	rofi -dmenu\
-		-i\
+		-no-config\
+        -i\
 		-no-fixed-num-lines\
 		-p "Are You Sure? : "\
 		-theme $dir/confirm.rasi
@@ -28,7 +29,7 @@ confirm_exit() {
 
 # Message
 msg() {
-	rofi -theme "$dir/message.rasi" -e "Available Options  -  yes / y / no / n"
+	rofi -no-config -theme "$dir/message.rasi" -e "Available Options  -  yes / y / no / n"
 }
 
 # Variable passed to rofi

--- a/bitmap/hack/scripts/powermenu.sh
+++ b/bitmap/hack/scripts/powermenu.sh
@@ -8,7 +8,7 @@
 dir="~/.config/polybar/hack/scripts/rofi"
 uptime=$(uptime -p | sed -e 's/up //g')
 
-rofi_command="rofi -theme $dir/powermenu.rasi"
+rofi_command="rofi -no-config -theme $dir/powermenu.rasi"
 
 # Options
 shutdown=" Shutdown"

--- a/bitmap/material/scripts/powermenu.sh
+++ b/bitmap/material/scripts/powermenu.sh
@@ -8,7 +8,7 @@
 dir="~/.config/polybar/material/scripts/rofi"
 uptime=$(uptime -p | sed -e 's/up //g')
 
-rofi_command="rofi -theme $dir/powermenu.rasi"
+rofi_command="rofi -no-config -theme $dir/powermenu.rasi"
 
 # Options
 shutdown=" Shutdown"

--- a/bitmap/material/scripts/powermenu.sh
+++ b/bitmap/material/scripts/powermenu.sh
@@ -20,7 +20,8 @@ logout=" Logout"
 # Confirmation
 confirm_exit() {
 	rofi -dmenu\
-		-i\
+		-no-config\
+        -i\
 		-no-fixed-num-lines\
 		-p "Are You Sure? : "\
 		-theme $dir/confirm.rasi
@@ -28,7 +29,7 @@ confirm_exit() {
 
 # Message
 msg() {
-	rofi -theme "$dir/message.rasi" -e "Available Options  -  yes / y / no / n"
+	rofi -no-config -theme "$dir/message.rasi" -e "Available Options  -  yes / y / no / n"
 }
 
 # Variable passed to rofi

--- a/bitmap/shades/scripts/powermenu.sh
+++ b/bitmap/shades/scripts/powermenu.sh
@@ -8,7 +8,7 @@
 dir="~/.config/polybar/shades/scripts/rofi"
 uptime=$(uptime -p | sed -e 's/up //g')
 
-rofi_command="rofi -theme $dir/powermenu.rasi"
+rofi_command="rofi -no-config -theme $dir/powermenu.rasi"
 
 # Options
 shutdown=" Shutdown"

--- a/bitmap/shades/scripts/powermenu.sh
+++ b/bitmap/shades/scripts/powermenu.sh
@@ -20,7 +20,8 @@ logout=" Logout"
 # Confirmation
 confirm_exit() {
 	rofi -dmenu\
-		-i\
+		-no-config\
+        -i\
 		-no-fixed-num-lines\
 		-p "Are You Sure? : "\
 		-theme $dir/confirm.rasi
@@ -28,7 +29,7 @@ confirm_exit() {
 
 # Message
 msg() {
-	rofi -theme "$dir/message.rasi" -e "Available Options  -  yes / y / no / n"
+	rofi -no-config -theme "$dir/message.rasi" -e "Available Options  -  yes / y / no / n"
 }
 
 # Variable passed to rofi

--- a/bitmap/shapes/scripts/powermenu.sh
+++ b/bitmap/shapes/scripts/powermenu.sh
@@ -20,7 +20,8 @@ logout=" Logout"
 # Confirmation
 confirm_exit() {
 	rofi -dmenu\
-		-i\
+		-no-config\
+        -i\
 		-no-fixed-num-lines\
 		-p "Are You Sure? : "\
 		-theme $dir/confirm.rasi
@@ -28,7 +29,7 @@ confirm_exit() {
 
 # Message
 msg() {
-	rofi -theme "$dir/message.rasi" -e "Available Options  -  yes / y / no / n"
+	rofi -no-config -theme "$dir/message.rasi" -e "Available Options  -  yes / y / no / n"
 }
 
 # Variable passed to rofi

--- a/bitmap/shapes/scripts/powermenu.sh
+++ b/bitmap/shapes/scripts/powermenu.sh
@@ -8,7 +8,7 @@
 dir="~/.config/polybar/shapes/scripts/rofi"
 uptime=$(uptime -p | sed -e 's/up //g')
 
-rofi_command="rofi -theme $dir/powermenu.rasi"
+rofi_command="rofi -no-config -theme $dir/powermenu.rasi"
 
 # Options
 shutdown=" Shutdown"

--- a/simple/blocks/scripts/powermenu.sh
+++ b/simple/blocks/scripts/powermenu.sh
@@ -8,7 +8,7 @@
 dir="~/.config/polybar/blocks/scripts/rofi"
 uptime=$(uptime -p | sed -e 's/up //g')
 
-rofi_command="rofi -theme $dir/powermenu.rasi"
+rofi_command="rofi -no-config -theme $dir/powermenu.rasi"
 
 # Options
 shutdown=" Shutdown"

--- a/simple/blocks/scripts/powermenu.sh
+++ b/simple/blocks/scripts/powermenu.sh
@@ -20,6 +20,7 @@ logout=" Logout"
 # Confirmation
 confirm_exit() {
 	rofi -dmenu\
+        -no-config\
 		-i\
 		-no-fixed-num-lines\
 		-p "Are You Sure? : "\
@@ -28,7 +29,7 @@ confirm_exit() {
 
 # Message
 msg() {
-	rofi -theme "$dir/message.rasi" -e "Available Options  -  yes / y / no / n"
+	rofi -no-config -theme "$dir/message.rasi" -e "Available Options  -  yes / y / no / n"
 }
 
 # Variable passed to rofi

--- a/simple/colorblocks/scripts/powermenu.sh
+++ b/simple/colorblocks/scripts/powermenu.sh
@@ -8,7 +8,7 @@
 dir="~/.config/polybar/colorblocks/scripts/rofi"
 uptime=$(uptime -p | sed -e 's/up //g')
 
-rofi_command="rofi -theme $dir/powermenu.rasi"
+rofi_command="rofi -no-config -theme $dir/powermenu.rasi"
 
 # Options
 shutdown=" Shutdown"

--- a/simple/colorblocks/scripts/powermenu.sh
+++ b/simple/colorblocks/scripts/powermenu.sh
@@ -20,6 +20,7 @@ logout=" Logout"
 # Confirmation
 confirm_exit() {
 	rofi -dmenu\
+        -no-config\
 		-i\
 		-no-fixed-num-lines\
 		-p "Are You Sure? : "\
@@ -28,7 +29,7 @@ confirm_exit() {
 
 # Message
 msg() {
-	rofi -theme "$dir/message.rasi" -e "Available Options  -  yes / y / no / n"
+	rofi -no-config -theme "$dir/message.rasi" -e "Available Options  -  yes / y / no / n"
 }
 
 # Variable passed to rofi

--- a/simple/cuts/scripts/powermenu.sh
+++ b/simple/cuts/scripts/powermenu.sh
@@ -8,7 +8,7 @@
 dir="~/.config/polybar/cuts/scripts/rofi"
 uptime=$(uptime -p | sed -e 's/up //g')
 
-rofi_command="rofi -theme $dir/powermenu.rasi"
+rofi_command="rofi -no-config -theme $dir/powermenu.rasi"
 
 # Options
 shutdown=" Shutdown"

--- a/simple/cuts/scripts/powermenu.sh
+++ b/simple/cuts/scripts/powermenu.sh
@@ -20,6 +20,7 @@ logout=" Logout"
 # Confirmation
 confirm_exit() {
 	rofi -dmenu\
+        -no-config\
 		-i\
 		-no-fixed-num-lines\
 		-p "Are You Sure? : "\
@@ -28,7 +29,7 @@ confirm_exit() {
 
 # Message
 msg() {
-	rofi -theme "$dir/message.rasi" -e "Available Options  -  yes / y / no / n"
+	rofi -no-config -theme "$dir/message.rasi" -e "Available Options  -  yes / y / no / n"
 }
 
 # Variable passed to rofi

--- a/simple/docky/scripts/powermenu.sh
+++ b/simple/docky/scripts/powermenu.sh
@@ -20,6 +20,7 @@ logout=" Logout"
 # Confirmation
 confirm_exit() {
 	rofi -dmenu\
+        -no-config\
 		-i\
 		-no-fixed-num-lines\
 		-p "Are You Sure? : "\
@@ -28,7 +29,7 @@ confirm_exit() {
 
 # Message
 msg() {
-	rofi -theme "$dir/message.rasi" -e "Available Options  -  yes / y / no / n"
+	rofi -no-config -theme "$dir/message.rasi" -e "Available Options  -  yes / y / no / n"
 }
 
 # Variable passed to rofi

--- a/simple/docky/scripts/powermenu.sh
+++ b/simple/docky/scripts/powermenu.sh
@@ -8,7 +8,7 @@
 dir="~/.config/polybar/docky/scripts/rofi"
 uptime=$(uptime -p | sed -e 's/up //g')
 
-rofi_command="rofi -theme $dir/powermenu.rasi"
+rofi_command="rofi -no-config -theme $dir/powermenu.rasi"
 
 # Options
 shutdown=" Shutdown"

--- a/simple/forest/scripts/powermenu.sh
+++ b/simple/forest/scripts/powermenu.sh
@@ -8,7 +8,7 @@
 dir="~/.config/polybar/forest/scripts/rofi"
 uptime=$(uptime -p | sed -e 's/up //g')
 
-rofi_command="rofi -theme $dir/powermenu.rasi"
+rofi_command="rofi -no-config -theme $dir/powermenu.rasi"
 
 # Options
 shutdown=" Shutdown"

--- a/simple/forest/scripts/powermenu.sh
+++ b/simple/forest/scripts/powermenu.sh
@@ -20,6 +20,7 @@ logout=" Logout"
 # Confirmation
 confirm_exit() {
 	rofi -dmenu\
+        -no-config\
 		-i\
 		-no-fixed-num-lines\
 		-p "Are You Sure? : "\
@@ -28,7 +29,7 @@ confirm_exit() {
 
 # Message
 msg() {
-	rofi -theme "$dir/message.rasi" -e "Available Options  -  yes / y / no / n"
+	rofi -no-config -theme "$dir/message.rasi" -e "Available Options  -  yes / y / no / n"
 }
 
 # Variable passed to rofi

--- a/simple/grayblocks/scripts/powermenu.sh
+++ b/simple/grayblocks/scripts/powermenu.sh
@@ -8,7 +8,7 @@
 dir="~/.config/polybar/grayblocks/scripts/rofi"
 uptime=$(uptime -p | sed -e 's/up //g')
 
-rofi_command="rofi -theme $dir/powermenu.rasi"
+rofi_command="rofi -no-config -theme $dir/powermenu.rasi"
 
 # Options
 shutdown=" Shutdown"

--- a/simple/grayblocks/scripts/powermenu.sh
+++ b/simple/grayblocks/scripts/powermenu.sh
@@ -20,6 +20,7 @@ logout=" Logout"
 # Confirmation
 confirm_exit() {
 	rofi -dmenu\
+        -no-config\
 		-i\
 		-no-fixed-num-lines\
 		-p "Are You Sure? : "\
@@ -28,7 +29,7 @@ confirm_exit() {
 
 # Message
 msg() {
-	rofi -theme "$dir/message.rasi" -e "Available Options  -  yes / y / no / n"
+	rofi -no-config -theme "$dir/message.rasi" -e "Available Options  -  yes / y / no / n"
 }
 
 # Variable passed to rofi

--- a/simple/hack/scripts/powermenu.sh
+++ b/simple/hack/scripts/powermenu.sh
@@ -8,7 +8,7 @@
 dir="~/.config/polybar/hack/scripts/rofi"
 uptime=$(uptime -p | sed -e 's/up //g')
 
-rofi_command="rofi -theme $dir/powermenu.rasi"
+rofi_command="rofi -no-config -theme $dir/powermenu.rasi"
 
 # Options
 shutdown=" Shutdown"

--- a/simple/hack/scripts/powermenu.sh
+++ b/simple/hack/scripts/powermenu.sh
@@ -20,6 +20,7 @@ logout=" Logout"
 # Confirmation
 confirm_exit() {
 	rofi -dmenu\
+        -no-config\
 		-i\
 		-no-fixed-num-lines\
 		-p "Are You Sure? : "\
@@ -28,7 +29,7 @@ confirm_exit() {
 
 # Message
 msg() {
-	rofi -theme "$dir/message.rasi" -e "Available Options  -  yes / y / no / n"
+	rofi -no-config -theme "$dir/message.rasi" -e "Available Options  -  yes / y / no / n"
 }
 
 # Variable passed to rofi

--- a/simple/material/scripts/powermenu.sh
+++ b/simple/material/scripts/powermenu.sh
@@ -8,7 +8,7 @@
 dir="~/.config/polybar/material/scripts/rofi"
 uptime=$(uptime -p | sed -e 's/up //g')
 
-rofi_command="rofi -theme $dir/powermenu.rasi"
+rofi_command="rofi -no-config -theme $dir/powermenu.rasi"
 
 # Options
 shutdown=" Shutdown"
@@ -20,6 +20,7 @@ logout=" Logout"
 # Confirmation
 confirm_exit() {
 	rofi -dmenu\
+        -no-config\
 		-i\
 		-no-fixed-num-lines\
 		-p "Are You Sure? : "\
@@ -28,7 +29,7 @@ confirm_exit() {
 
 # Message
 msg() {
-	rofi -theme "$dir/message.rasi" -e "Available Options  -  yes / y / no / n"
+	rofi -no-config -theme "$dir/message.rasi" -e "Available Options  -  yes / y / no / n"
 }
 
 # Variable passed to rofi

--- a/simple/panels/scripts/powermenu.sh
+++ b/simple/panels/scripts/powermenu.sh
@@ -64,6 +64,7 @@ logout=" Logout"
 # Confirmation
 confirm_exit() {
 	rofi -dmenu\
+        -no-config\
 		-i\
 		-no-fixed-num-lines\
 		-p "Are You Sure? : "\
@@ -72,7 +73,7 @@ confirm_exit() {
 
 # Message
 msg() {
-	rofi -theme "$DIR/$theme/message.rasi" -e "Available Options  -  yes / y / no / n"
+	rofi -no-config -theme "$DIR/$theme/message.rasi" -e "Available Options  -  yes / y / no / n"
 }
 
 # Variable passed to rofi

--- a/simple/panels/scripts/powermenu.sh
+++ b/simple/panels/scripts/powermenu.sh
@@ -52,7 +52,7 @@ else
 	exit 1
 fi
 
-rofi_command="rofi -theme $DIR/$theme/powermenu.rasi"
+rofi_command="rofi -no-config -theme $DIR/powermenu.rasi"
 
 # Options
 shutdown=" Shutdown"

--- a/simple/pwidgets/scripts/powermenu.sh
+++ b/simple/pwidgets/scripts/powermenu.sh
@@ -20,6 +20,7 @@ logout=" Logout"
 # Confirmation
 confirm_exit() {
 	rofi -dmenu\
+        -no-config\
 		-i\
 		-no-fixed-num-lines\
 		-p "Are You Sure? : "\
@@ -28,7 +29,7 @@ confirm_exit() {
 
 # Message
 msg() {
-	rofi -theme "$dir/message.rasi" -e "Options : yes / y / no / n"
+	rofi -no-config -theme "$dir/message.rasi" -e "Options : yes / y / no / n"
 }
 
 # Variable passed to rofi

--- a/simple/pwidgets/scripts/powermenu.sh
+++ b/simple/pwidgets/scripts/powermenu.sh
@@ -8,7 +8,7 @@
 dir="~/.config/polybar/pwidgets/scripts/rofi"
 uptime=$(uptime -p | sed -e 's/up //g')
 
-rofi_command="rofi -theme $dir/powermenu.rasi"
+rofi_command="rofi -no-config -theme $dir/powermenu.rasi"
 
 # Options
 shutdown=" Shutdown"

--- a/simple/shades/scripts/powermenu.sh
+++ b/simple/shades/scripts/powermenu.sh
@@ -8,7 +8,7 @@
 dir="~/.config/polybar/shades/scripts/rofi"
 uptime=$(uptime -p | sed -e 's/up //g')
 
-rofi_command="rofi -theme $dir/powermenu.rasi"
+rofi_command="rofi -no-config -theme $dir/powermenu.rasi"
 
 # Options
 shutdown=" Shutdown"

--- a/simple/shades/scripts/powermenu.sh
+++ b/simple/shades/scripts/powermenu.sh
@@ -20,6 +20,7 @@ logout=" Logout"
 # Confirmation
 confirm_exit() {
 	rofi -dmenu\
+        -no-config\
 		-i\
 		-no-fixed-num-lines\
 		-p "Are You Sure? : "\
@@ -28,7 +29,7 @@ confirm_exit() {
 
 # Message
 msg() {
-	rofi -theme "$dir/message.rasi" -e "Available Options  -  yes / y / no / n"
+	rofi -no-config -theme "$dir/message.rasi" -e "Available Options  -  yes / y / no / n"
 }
 
 # Variable passed to rofi

--- a/simple/shapes/scripts/powermenu.sh
+++ b/simple/shapes/scripts/powermenu.sh
@@ -8,7 +8,7 @@
 dir="~/.config/polybar/shapes/scripts/rofi"
 uptime=$(uptime -p | sed -e 's/up //g')
 
-rofi_command="rofi -theme $dir/powermenu.rasi"
+rofi_command="rofi -no-config -theme $dir/powermenu.rasi"
 
 # Options
 shutdown=" Shutdown"

--- a/simple/shapes/scripts/powermenu.sh
+++ b/simple/shapes/scripts/powermenu.sh
@@ -20,6 +20,7 @@ logout=" Logout"
 # Confirmation
 confirm_exit() {
 	rofi -dmenu\
+        -no-config\
 		-i\
 		-no-fixed-num-lines\
 		-p "Are You Sure? : "\
@@ -28,7 +29,7 @@ confirm_exit() {
 
 # Message
 msg() {
-	rofi -theme "$dir/message.rasi" -e "Available Options  -  yes / y / no / n"
+	rofi -no-config -theme "$dir/message.rasi" -e "Available Options  -  yes / y / no / n"
 }
 
 # Variable passed to rofi


### PR DESCRIPTION
Rofi powermenu will unproperly displayed if rofi config exist in the client, because there will be conflict with the theme which the script try to load.
It looked like this at my end:
![image](https://user-images.githubusercontent.com/13470318/117548008-c1cf4c00-b05c-11eb-86cb-eed3aa95759d.png)

I found that it because the powermenu script run rofi without `-no-config` option, so I added this option to the command, confirm and message section in all themes. Pretty sure we want consistent behaviour like the launcher script does. 
And it looked better:
![image](https://user-images.githubusercontent.com/13470318/117548328-95b4ca80-b05e-11eb-89e0-9b9df49faeae.png)

