### PR TITLE
fix: correct colors

### DIFF
--- a/simple/forest/scripts/rofi/launcher.rasi
+++ b/simple/forest/scripts/rofi/launcher.rasi
@@ -97,6 +97,7 @@ element {
 element-icon {
     size:                           24px;
     border:                         0px;
+    background-color: transparent;
 }
 
 element-text {
@@ -104,12 +105,17 @@ element-text {
     horizontal-align:               0;
     vertical-align:                 0.5;
     margin:                         0px 2.5px 0px 2.5px;
+    background-color: transparent;
+    color: @fg;
 }
 
-element selected {
+element.selected {
     background-color:               @se;
-    text-color:                     @bg;
 	border:							0px 0px 0px 0px;
     border-radius:                  0px;
     border-color:                  	@ac;
+}
+
+element-text.selected {
+    text-color:                     @bg;
 }


### PR DESCRIPTION
Newer versions of rofi cause white boxes where proper theme colors should otherwise be.