### PR TITLE
Fix update module arch linux

### DIFF
--- a/bitmap/blocks/scripts/updates.sh
+++ b/bitmap/blocks/scripts/updates.sh
@@ -2,7 +2,7 @@
 
 NOTIFY_ICON=/usr/share/icons/Papirus/32x32/apps/system-software-update.svg
 
-get_total_updates() { UPDATES=$(checkupdates 2>/dev/null | wc -l); }
+get_total_updates() { UPDATES=$(~/.config/polybar/blocks/scripts/checkupdates 2>/dev/null | wc -l); }
 
 while true; do
     get_total_updates

--- a/bitmap/colorblocks/scripts/updates.sh
+++ b/bitmap/colorblocks/scripts/updates.sh
@@ -2,7 +2,7 @@
 
 NOTIFY_ICON=/usr/share/icons/Papirus/32x32/apps/system-software-update.svg
 
-get_total_updates() { UPDATES=$(checkupdates 2>/dev/null | wc -l); }
+get_total_updates() { UPDATES=$(~/.config/polybar/colorblocks/scripts/checkupdates 2>/dev/null | wc -l); }
 
 while true; do
     get_total_updates

--- a/bitmap/cuts/scripts/updates.sh
+++ b/bitmap/cuts/scripts/updates.sh
@@ -2,7 +2,7 @@
 
 NOTIFY_ICON=/usr/share/icons/Papirus/32x32/apps/system-software-update.svg
 
-get_total_updates() { UPDATES=$(checkupdates 2>/dev/null | wc -l); }
+get_total_updates() { UPDATES=$(~/.config/polybar/cuts/scripts/checkupdates 2>/dev/null | wc -l); }
 
 while true; do
     get_total_updates

--- a/bitmap/docky/scripts/updates.sh
+++ b/bitmap/docky/scripts/updates.sh
@@ -2,7 +2,7 @@
 
 NOTIFY_ICON=/usr/share/icons/Papirus/32x32/apps/system-software-update.svg
 
-get_total_updates() { UPDATES=$(checkupdates 2>/dev/null | wc -l); }
+get_total_updates() { UPDATES=$(~/.config/polybar/docky/scripts/checkupdates 2>/dev/null | wc -l); }
 
 while true; do
     get_total_updates

--- a/bitmap/forest/scripts/updates.sh
+++ b/bitmap/forest/scripts/updates.sh
@@ -2,7 +2,7 @@
 
 NOTIFY_ICON=/usr/share/icons/Papirus/32x32/apps/system-software-update.svg
 
-get_total_updates() { UPDATES=$(checkupdates 2>/dev/null | wc -l); }
+get_total_updates() { UPDATES=$(~/.config/polybar/forest/scripts/checkupdates 2>/dev/null | wc -l); }
 
 while true; do
     get_total_updates

--- a/bitmap/grayblocks/scripts/updates.sh
+++ b/bitmap/grayblocks/scripts/updates.sh
@@ -2,7 +2,7 @@
 
 NOTIFY_ICON=/usr/share/icons/Papirus/32x32/apps/system-software-update.svg
 
-get_total_updates() { UPDATES=$(checkupdates 2>/dev/null | wc -l); }
+get_total_updates() { UPDATES=$(~/.config/polybar/grayblocks/scripts/checkupdates 2>/dev/null | wc -l); }
 
 while true; do
     get_total_updates

--- a/bitmap/hack/scripts/updates.sh
+++ b/bitmap/hack/scripts/updates.sh
@@ -2,7 +2,7 @@
 
 NOTIFY_ICON=/usr/share/icons/Papirus/32x32/apps/system-software-update.svg
 
-get_total_updates() { UPDATES=$(checkupdates 2>/dev/null | wc -l); }
+get_total_updates() { UPDATES=$(~/.config/polybar/hack/scripts/checkupdates 2>/dev/null | wc -l); }
 
 while true; do
     get_total_updates

--- a/bitmap/material/scripts/updates.sh
+++ b/bitmap/material/scripts/updates.sh
@@ -2,7 +2,7 @@
 
 NOTIFY_ICON=/usr/share/icons/Papirus/32x32/apps/system-software-update.svg
 
-get_total_updates() { UPDATES=$(checkupdates 2>/dev/null | wc -l); }
+get_total_updates() { UPDATES=$(~/.config/polybar/material/scripts/checkupdates 2>/dev/null | wc -l); }
 
 while true; do
     get_total_updates

--- a/bitmap/shades/scripts/updates.sh
+++ b/bitmap/shades/scripts/updates.sh
@@ -2,7 +2,7 @@
 
 NOTIFY_ICON=/usr/share/icons/Papirus/32x32/apps/system-software-update.svg
 
-get_total_updates() { UPDATES=$(checkupdates 2>/dev/null | wc -l); }
+get_total_updates() { UPDATES=$(~/.config/polybar/shades/scripts/checkupdates 2>/dev/null | wc -l); }
 
 while true; do
     get_total_updates

--- a/bitmap/shapes/scripts/updates.sh
+++ b/bitmap/shapes/scripts/updates.sh
@@ -2,7 +2,7 @@
 
 NOTIFY_ICON=/usr/share/icons/Papirus/32x32/apps/system-software-update.svg
 
-get_total_updates() { UPDATES=$(checkupdates 2>/dev/null | wc -l); }
+get_total_updates() { UPDATES=$(~/.config/polybar/shapes/scripts/checkupdates 2>/dev/null | wc -l); }
 
 while true; do
     get_total_updates

--- a/simple/blocks/scripts/updates.sh
+++ b/simple/blocks/scripts/updates.sh
@@ -2,7 +2,7 @@
 
 NOTIFY_ICON=/usr/share/icons/Papirus/32x32/apps/system-software-update.svg
 
-get_total_updates() { UPDATES=$(checkupdates 2>/dev/null | wc -l); }
+get_total_updates() { UPDATES=$(~/.config/polybar/blocks/scripts/checkupdates 2>/dev/null | wc -l); }
 
 while true; do
     get_total_updates

--- a/simple/colorblocks/scripts/updates.sh
+++ b/simple/colorblocks/scripts/updates.sh
@@ -2,7 +2,7 @@
 
 NOTIFY_ICON=/usr/share/icons/Papirus/32x32/apps/system-software-update.svg
 
-get_total_updates() { UPDATES=$(checkupdates 2>/dev/null | wc -l); }
+get_total_updates() { UPDATES=$(~/.config/polybar/colorblocks/scripts/checkupdates 2>/dev/null | wc -l); }
 
 while true; do
     get_total_updates

--- a/simple/cuts/scripts/updates.sh
+++ b/simple/cuts/scripts/updates.sh
@@ -2,7 +2,7 @@
 
 NOTIFY_ICON=/usr/share/icons/Papirus/32x32/apps/system-software-update.svg
 
-get_total_updates() { UPDATES=$(checkupdates 2>/dev/null | wc -l); }
+get_total_updates() { UPDATES=$(~/.config/polybar/cuts/scripts/checkupdates 2>/dev/null | wc -l); }
 
 while true; do
     get_total_updates

--- a/simple/docky/scripts/updates.sh
+++ b/simple/docky/scripts/updates.sh
@@ -2,7 +2,7 @@
 
 NOTIFY_ICON=/usr/share/icons/Papirus/32x32/apps/system-software-update.svg
 
-get_total_updates() { UPDATES=$(checkupdates 2>/dev/null | wc -l); }
+get_total_updates() { UPDATES=$(~/.config/polybar/docky/scripts/checkupdates 2>/dev/null | wc -l); }
 
 while true; do
     get_total_updates

--- a/simple/forest/scripts/updates.sh
+++ b/simple/forest/scripts/updates.sh
@@ -2,7 +2,7 @@
 
 NOTIFY_ICON=/usr/share/icons/Papirus/32x32/apps/system-software-update.svg
 
-get_total_updates() { UPDATES=$(checkupdates 2>/dev/null | wc -l); }
+get_total_updates() { UPDATES=$(~/.config/polybar/forest/scripts/checkupdates 2>/dev/null | wc -l); }
 
 while true; do
     get_total_updates

--- a/simple/grayblocks/scripts/updates.sh
+++ b/simple/grayblocks/scripts/updates.sh
@@ -2,7 +2,7 @@
 
 NOTIFY_ICON=/usr/share/icons/Papirus/32x32/apps/system-software-update.svg
 
-get_total_updates() { UPDATES=$(checkupdates 2>/dev/null | wc -l); }
+get_total_updates() { UPDATES=$(~/.config/polybar/grayblocks/scripts/checkupdates 2>/dev/null | wc -l); }
 
 while true; do
     get_total_updates

--- a/simple/hack/scripts/updates.sh
+++ b/simple/hack/scripts/updates.sh
@@ -2,7 +2,7 @@
 
 NOTIFY_ICON=/usr/share/icons/Papirus/32x32/apps/system-software-update.svg
 
-get_total_updates() { UPDATES=$(checkupdates 2>/dev/null | wc -l); }
+get_total_updates() { UPDATES=$(~/.config/polybar/hack/scripts/checkupdates 2>/dev/null | wc -l); }
 
 while true; do
     get_total_updates

--- a/simple/material/scripts/updates.sh
+++ b/simple/material/scripts/updates.sh
@@ -2,7 +2,7 @@
 
 NOTIFY_ICON=/usr/share/icons/Papirus/32x32/apps/system-software-update.svg
 
-get_total_updates() { UPDATES=$(checkupdates 2>/dev/null | wc -l); }
+get_total_updates() { UPDATES=$(~/.config/polybar/material/scripts/checkupdates 2>/dev/null | wc -l); }
 
 while true; do
     get_total_updates

--- a/simple/shades/scripts/updates.sh
+++ b/simple/shades/scripts/updates.sh
@@ -2,7 +2,7 @@
 
 NOTIFY_ICON=/usr/share/icons/Papirus/32x32/apps/system-software-update.svg
 
-get_total_updates() { UPDATES=$(~/.config/polybar/hack/shades/checkupdates 2>/dev/null | wc -l); }
+get_total_updates() { UPDATES=$(~/.config/polybar/shades/scripts/checkupdates 2>/dev/null | wc -l); }
 
 while true; do
     get_total_updates

--- a/simple/shades/scripts/updates.sh
+++ b/simple/shades/scripts/updates.sh
@@ -2,7 +2,7 @@
 
 NOTIFY_ICON=/usr/share/icons/Papirus/32x32/apps/system-software-update.svg
 
-get_total_updates() { UPDATES=$(checkupdates 2>/dev/null | wc -l); }
+get_total_updates() { UPDATES=$(~/.config/polybar/hack/shades/checkupdates 2>/dev/null | wc -l); }
 
 while true; do
     get_total_updates

--- a/simple/shapes/scripts/updates.sh
+++ b/simple/shapes/scripts/updates.sh
@@ -2,7 +2,7 @@
 
 NOTIFY_ICON=/usr/share/icons/Papirus/32x32/apps/system-software-update.svg
 
-get_total_updates() { UPDATES=$(checkupdates 2>/dev/null | wc -l); }
+get_total_updates() { UPDATES=$(~/.config/polybar/shapes/scripts/checkupdates 2>/dev/null | wc -l); }
 
 while true; do
     get_total_updates


### PR DESCRIPTION
I fixed the module that shows the amount of update, because it wouldn't work for me. I suspect this is because when you ran `checkupdates` it thought you ran it as a command instead of running it as a file. There was a commit in the past that fixed this issue, but I guess updates after that point broke the fixes so I'm fixing it again.