### PR TITLE
Fixed powermenu.sh not targeting theme subdirectory

### DIFF
--- a/simple/panels/scripts/powermenu.sh
+++ b/simple/panels/scripts/powermenu.sh
@@ -52,7 +52,7 @@ else
 	exit 1
 fi
 
-rofi_command="rofi -no-config -theme $DIR/powermenu.rasi"
+rofi_command="rofi -no-config -theme $DIR/$theme/powermenu.rasi"
 
 # Options
 shutdown=" Shutdown"


### PR DESCRIPTION
The issue:
When selecting the simple theme _panels_, invoking the power menu would trigger an error where the program rofi would not find the file powermenu.rasi. Indeed, the path specified was incorrect, as it must contain the sub-directory related to the panel theme.