### PR TITLE
rofi error when clicking sysmenu

### DIFF
--- a/simple/panels/scripts/powermenu.sh
+++ b/simple/panels/scripts/powermenu.sh
@@ -52,7 +52,7 @@ else
 	exit 1
 fi
 
-rofi_command="rofi -no-config -theme $DIR/powermenu.rasi"
+rofi_command="rofi -no-config -theme $DIR/$theme/powermenu.rasi"
 
 # Options
 shutdown=" Shutdown"


### PR DESCRIPTION
there was a rofi error when trying to access sysmenu, it says that the file doesn't exist that's a result of forgetting to add theme variable in the rofi_command variable there.

thank you for this awesome themes anyway.