### PR TITLE
adding correct colors to battery bar

### DIFF
--- a/simple/cuts/bars.ini
+++ b/simple/cuts/bars.ini
@@ -242,11 +242,11 @@ bar-capacity-indicator = ${bar.indicator}
 bar-capacity-indicator-foreground = ${color.foreground}
 
 bar-capacity-fill = ${bar.fill}
-bar-capacity-foreground-0 = ${color.green}
-bar-capacity-foreground-1 = ${color.green}
+bar-capacity-foreground-0 = ${color.red}
+bar-capacity-foreground-1 = ${color.yellow}
 bar-capacity-foreground-2 = ${color.yellow}
-bar-capacity-foreground-3 = ${color.yellow}
-bar-capacity-foreground-4 = ${color.red}
+bar-capacity-foreground-3 = ${color.green}
+bar-capacity-foreground-4 = ${color.green}
 
 bar-capacity-empty = ${bar.empty}
 bar-capacity-empty-foreground = ${color.foreground-alt}

--- a/simple/forest/bars.ini
+++ b/simple/forest/bars.ini
@@ -243,11 +243,11 @@ bar-capacity-indicator-foreground = ${color.foreground}
 
 bar-capacity-fill = ${bar.fill}
 bar-capacity-fill-font = 2
-bar-capacity-foreground-0 = ${color.green}
-bar-capacity-foreground-1 = ${color.green}
+bar-capacity-foreground-0 = ${color.red}
+bar-capacity-foreground-1 = ${color.yellow}
 bar-capacity-foreground-2 = ${color.yellow}
-bar-capacity-foreground-3 = ${color.yellow}
-bar-capacity-foreground-4 = ${color.red}
+bar-capacity-foreground-3 = ${color.green}
+bar-capacity-foreground-4 = ${color.green}
 
 bar-capacity-empty = ${bar.empty}
 bar-capacity-empty-font = 2

--- a/simple/hack/bars.ini
+++ b/simple/hack/bars.ini
@@ -227,11 +227,11 @@ bar-capacity-indicator = ${bar.indicator}
 bar-capacity-indicator-foreground = ${color.foreground}
 
 bar-capacity-fill = ${bar.fill}
-bar-capacity-foreground-0 = ${color.green}
-bar-capacity-foreground-1 = ${color.green}
+bar-capacity-foreground-0 = ${color.red}
+bar-capacity-foreground-1 = ${color.yellow}
 bar-capacity-foreground-2 = ${color.yellow}
-bar-capacity-foreground-3 = ${color.yellow}
-bar-capacity-foreground-4 = ${color.red}
+bar-capacity-foreground-3 = ${color.green}
+bar-capacity-foreground-4 = ${color.green}
 
 bar-capacity-empty = ${bar.empty}
 bar-capacity-empty-foreground = ${color.foreground}


### PR DESCRIPTION
battery bar now shows green color for high battery and red for low battery

previously following fonts showed wrong colors:
1. hack
2. forest
3. cuts

the red color was shown for high battery
and green for low battery