### PR TITLE
fix: typo in modules-right

### DIFF
--- a/simple/forest/config.ini
+++ b/simple/forest/config.ini
@@ -141,7 +141,7 @@ font-2 = "feather:size=12;3"
 
 modules-left = launcher sep workspaces sep cpu memory filesystem
 modules-center = mpd sep date
-modules-right = battery network sep volume brightness sep sysmenu
+modules-right = battery network sep volume backlight sep sysmenu
 
 ;; _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_
 


### PR DESCRIPTION
There was a typo, where you have to write backlight instead of brightness for brightness to work.

#Line 144, 
@adi1090x