### PR TITLE
Added --disable-sandbox flag to the pacman -Sy command on line 109.

### DIFF
--- a/simple/forest/scripts/checkupdates
+++ b/simple/forest/scripts/checkupdates
@@ -22,35 +22,41 @@ declare -r myname='checkupdates'
 declare -r myver='1.0.0'
 
 plain() {
-	(( QUIET )) && return
-	local mesg=$1; shift
+	((QUIET)) && return
+	local mesg=$1
+	shift
 	printf "${BOLD}    ${mesg}${ALL_OFF}\n" "$@" >&1
 }
 
 msg() {
-	(( QUIET )) && return
-	local mesg=$1; shift
+	((QUIET)) && return
+	local mesg=$1
+	shift
 	printf "${GREEN}==>${ALL_OFF}${BOLD} ${mesg}${ALL_OFF}\n" "$@" >&1
 }
 
 msg2() {
-	(( QUIET )) && return
-	local mesg=$1; shift
+	((QUIET)) && return
+	local mesg=$1
+	shift
 	printf "${BLUE}  ->${ALL_OFF}${BOLD} ${mesg}${ALL_OFF}\n" "$@" >&1
 }
 
 ask() {
-	local mesg=$1; shift
+	local mesg=$1
+	shift
 	printf "${BLUE}::${ALL_OFF}${BOLD} ${mesg}${ALL_OFF}" "$@" >&1
 }
 
 warning() {
-	local mesg=$1; shift
+	local mesg=$1
+	shift
 	printf "${YELLOW}==> $(gettext "WARNING:")${ALL_OFF}${BOLD} ${mesg}${ALL_OFF}\n" "$@" >&2
 }
 
 error() {
-	local mesg=$1; shift
+	local mesg=$1
+	shift
 	printf "${RED}==> $(gettext "ERROR:")${ALL_OFF}${BOLD} ${mesg}${ALL_OFF}\n" "$@" >&2
 }
 
@@ -76,8 +82,7 @@ if [[ -t 2 && ! $USE_COLOR = "n" ]]; then
 fi
 readonly ALL_OFF BOLD BLUE GREEN RED YELLOW
 
-
-if (( $# > 0 )); then
+if (($# > 0)); then
 	echo "${myname} v${myver}"
 	echo
 	echo "Safely print a list of pending updates"
@@ -105,12 +110,12 @@ if [[ -z "$DBPath" ]] || [[ ! -d "$DBPath" ]]; then
 fi
 
 mkdir -p "$CHECKUPDATES_DB"
-ln -s "${DBPath}/local" "$CHECKUPDATES_DB" &> /dev/null
-if ! fakeroot -- pacman -Sy --dbpath "$CHECKUPDATES_DB" --logfile /dev/null &> /dev/null; then
-       error 'Cannot fetch updates'
-       exit 1
+ln -s "${DBPath}/local" "$CHECKUPDATES_DB" &>/dev/null
+if ! fakeroot -- pacman -Sy --dbpath "$CHECKUPDATES_DB" --logfile /dev/null --disable-sandbox &>/dev/null; then
+	error 'Cannot fetch updates'
+	exit 1
 fi
-pacman -Qu --dbpath "$CHECKUPDATES_DB" 2> /dev/null | grep -v '\[.*\]'
+pacman -Qu --dbpath "$CHECKUPDATES_DB" 2>/dev/null | grep -v '\[.*\]'
 
 exit 0
 


### PR DESCRIPTION
The issue:

Pacman 7.x introduced Landlock sandboxing for security, but it conflicts with fakeroot (which the script uses to avoid running as root). The sandbox fails with "Operation not permitted" when running under fakeroot.

The fix:

Added --disable-sandbox flag to the pacman -Sy command on line 109.